### PR TITLE
Add external applications section to custom theme

### DIFF
--- a/geonode/apps/customizations/templates/geonode-mapstore-client/snippets/custom_theme.html
+++ b/geonode/apps/customizations/templates/geonode-mapstore-client/snippets/custom_theme.html
@@ -16,6 +16,16 @@
 
 </style>
 
+<!-- 🚀 External Applications Section -->
+<div class="external-applications" style="padding: 1rem;">
+    <h2 style="margin-bottom: 0.5rem;">External Applications</h2>
+    <ul style="list-style-type: disc; padding-left: 1.5rem;">
+        <li><a href="/apps/app1/" target="_blank">App 1</a></li>
+        <li><a href="/apps/app2/" target="_blank">App 2</a></li>
+        <!-- Add more apps if needed -->
+    </ul>
+</div>
+
 {% endblock %}
 
 <style>


### PR DESCRIPTION
###  Description

This PR adds a basic UI section for showcasing external applications in the GeoNode MapStore client.

- Modified `custom_theme.html` under `geonode/apps/customizations/templates/geonode-mapstore-client/snippets/`
- Injected an "External Applications" section with placeholder links pointing to `/apps/app1/`, `/apps/app2/`
- Styled minimally for visual consistency

This addresses issue #15 by integrating a visible UI that hints at external application availability and interaction.

###  Notes

- Links are currently static and for demonstration. They can later be dynamically fetched based on available apps.
- No breaking changes; fallback behavior remains unchanged if external apps are absent.

---

Closes #15
